### PR TITLE
Updated RequestResponseView to handle navigation if text is edited

### DIFF
--- a/frontend/src/routes/checkpoint/+page.svelte
+++ b/frontend/src/routes/checkpoint/+page.svelte
@@ -12,7 +12,6 @@
         ForwardIntercepted,
         DropIntercepted,
         RunExtension,
-        GetInterceptFlag,
         ToggleIntercept,
         InterceptResponse,
     } from "../../lib/wailsjs/go/main/App";
@@ -290,8 +289,7 @@
     </AccordionItem>
     <!-- ... -->
 </Accordion>
-
-<div class="p-1 text-center">
+<div class="p-1 flex flex-col items-center">
     <div class="btn-group variant-filled-primary">
         <button
             disabled={error !== ""}
@@ -325,26 +323,35 @@
         >
         <!--<button disabled="true">Intercept Response</button>-->
     </div>
+    <div class="text-center">
+        {#if interceptedCount > 0}
+            <p>Intercept Queue: {interceptedCount}</p>
+        {:else}
+            <p>No items in interception queue</p>
+        {/if}
+    </div>
+    <div class="text-center">
+        {#if error === ""}
+            <p>No Error</p>
+        {:else}
+            <p>{error}</p>
+        {/if}
+    </div>
+    <div class='w-full filler-color flex justify-center'>
+        <div class="w-[50%]">
+        <CodeMirror
+            bind:value={intercepted}
+            lang={getLang(intercepted)}
+            class="text-xs"
+            theme={oneDark}
+            extensions={$marasiConfig.VimEnabled ? [vim()] : []}
+            lineWrapping={$lineWrap}
+        />
+        </div>
+    </div>
 </div>
-<div class="text-center">
-    {#if interceptedCount > 0}
-        <p>Intercept Queue: {interceptedCount}</p>
-    {:else}
-        <p>No items in interception queue</p>
-    {/if}
-</div>
-<div class="text-center">
-    {#if error === ""}
-        <p>No Error</p>
-    {:else}
-        <p>{error}</p>
-    {/if}
-</div>
-<CodeMirror
-    bind:value={intercepted}
-    lang={getLang(intercepted)}
-    class="text-xs"
-    theme={oneDark}
-    extensions={$marasiConfig.VimEnabled ? [vim()] : []}
-    lineWrapping={$lineWrap}
-/>
+<style>
+    .filler-color {
+        background-color: #282c34
+    }
+</style>

--- a/frontend/src/routes/launchpad/+page.svelte
+++ b/frontend/src/routes/launchpad/+page.svelte
@@ -87,7 +87,7 @@
 
     function openMetadata() {
         if (!currentItem || !currentItem.Request || !currentItem.Request.ID) return;
-        GetNote(currentItem.Request.ID.toString()).then((metadata) => {
+        GetMetadata(currentItem.Request.ID.toString()).then((metadata) => {
             const modal = {
                 type: "component",
                 component: "Metadata",

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tfkr-ae/marasi v0.0.0-20250930163737-fe3d657a49dd h1:YBcqulTw5IGuMwqlNDWRw7RJiPG2AH6Mp9w+wikhpEU=
-github.com/tfkr-ae/marasi v0.0.0-20250930163737-fe3d657a49dd/go.mod h1:bObpISKGeJO16Sr5d/3eOjgfB+FCyvmwvsqzTTC/1d4=
 github.com/tfkr-ae/marasi v0.0.0-20250930171445-633727cff735 h1:x/PHa0kkP9TZgg7h+9JtOjH4piLSClwVwyq4YeYyOiE=
 github.com/tfkr-ae/marasi v0.0.0-20250930171445-633727cff735/go.mod h1:bObpISKGeJO16Sr5d/3eOjgfB+FCyvmwvsqzTTC/1d4=
 github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo3DLVQQ=


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the frontend Svelte components, focusing on user experience enhancements and codebase consistency. The most notable changes are grouped below by theme.

**Navigation and User Experience Improvements:**

* Added a navigation guard in `RequestResponseView.svelte` that prompts users with a confirmation modal if they attempt to navigate away with unsaved changes, preventing accidental data loss.
* Improved the UI layout in `checkpoint/+page.svelte` by switching to a flexbox-based column layout for button groups and centering content, resulting in a more visually appealing and consistent interface. [[1]](diffhunk://#diff-c207a417e437a014e8dfb4459a7d9dc0ce1e15732c70a1343a42d6002f1a4904L293-R292) [[2]](diffhunk://#diff-c207a417e437a014e8dfb4459a7d9dc0ce1e15732c70a1343a42d6002f1a4904L328)
* Enhanced the display of intercepted request data by wrapping the `CodeMirror` editor in a styled container, improving readability and aesthetics. [[1]](diffhunk://#diff-c207a417e437a014e8dfb4459a7d9dc0ce1e15732c70a1343a42d6002f1a4904R340-R341) [[2]](diffhunk://#diff-c207a417e437a014e8dfb4459a7d9dc0ce1e15732c70a1343a42d6002f1a4904R350-R357)

**Codebase Consistency and Refactoring:**

* Updated the metadata retrieval function in `launchpad/+page.svelte` from `GetNote` to `GetMetadata` for clarity and consistency with naming conventions.
* Removed the unused `GetInterceptFlag` import from `checkpoint/+page.svelte`, cleaning up the codebase.